### PR TITLE
Add configuration option to hide sidebar icon

### DIFF
--- a/src/main/java/com/sololegends/runelite/FriendsOnMapConfig.java
+++ b/src/main/java/com/sololegends/runelite/FriendsOnMapConfig.java
@@ -55,6 +55,11 @@ public interface FriendsOnMapConfig extends Config {
     return UpdateIntervalEnum.SECONDS_2;
   }
 
+  @ConfigItem(position = 3, section = "General", keyName = "show_sidebar_icon", name = "Show icon in sidebar", description = "Whether to display the Friends On Map sidebar icon")
+  default boolean showSidebarIcon() {
+    return true;
+  }
+
   // STYLING CONFIGURATION
 
   @ConfigItem(position = 11, section = styling_section, keyName = "style_dot_color", name = "Dot Color", description = "What color the dot is for your friends on the main map")

--- a/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
+++ b/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
@@ -130,7 +130,9 @@ public class FriendsOnMapPlugin extends Plugin {
         .build();
 
     // TODO: Enable when ready
-    clientToolbar.addNavigation(side_panel_btn);
+    if (config.showSidebarIcon()) {
+      clientToolbar.addNavigation(side_panel_btn);
+    }
   }
 
   @Override
@@ -469,6 +471,12 @@ public class FriendsOnMapPlugin extends Plugin {
     if (event.getKey().equals("always_show_name")) {
       for (FriendMapPoint mp : current_points) {
         updateFriendPointIcon(mp, true);
+      }
+    } else if (event.getKey().equals("show_sidebar_icon")) {
+      if (config.showSidebarIcon()) {
+        clientToolbar.addNavigation(side_panel_btn);
+      } else {
+        clientToolbar.removeNavigation(side_panel_btn);
       }
     }
   }


### PR DESCRIPTION
Some players may not have a need for the sidebar panel in this plugin. This PR adds a configuration option to hide the sidebar icon, reducing clutter and adding room for other plugins. By default, the sidebar icon is enabled.

![2023-11-09_17-41-00](https://github.com/sololegends/runelite-friend-finder/assets/6306331/dc2a8915-cc12-4089-9c22-2ade9c879dbb)

![2023-11-09_17-41-02](https://github.com/sololegends/runelite-friend-finder/assets/6306331/1d8b2fdd-977b-4615-8ccf-06a947fd8640)