### PR TITLE
Improve map drawing

### DIFF
--- a/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
+++ b/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
@@ -338,12 +338,14 @@ public class FriendsOnMapPlugin extends Plugin {
     Color owc = translated ? config.otherWorldColorLink() : config.otherWorldColor();
     Color wc = translated ? config.dotColorLink() : config.dotColor();
 
-    g.setColor(off_world && !config.offWorldAsOutline() ? owc : wc);
-    g.fillOval(x, y, d_size, d_size);
     if (off_world && config.offWorldAsOutline()) {
       g.setColor(owc);
-      g.setStroke(new BasicStroke(Math.max(2, config.outlineSize())));
-      g.drawOval(x, y, d_size, d_size);
+      g.fillOval(x, y, d_size, d_size);
+      g.setColor(wc);
+      g.fillOval(x + config.outlineSize(), y + config.outlineSize(), d_size - config.outlineSize() * 2, d_size - config.outlineSize() * 2);
+    } else {
+      g.setColor(off_world && !config.offWorldAsOutline() ? owc : wc);
+      g.fillOval(x, y, d_size, d_size);
     }
     g.setColor(oc);
     return new Dimension(d_size, d_size);

--- a/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
+++ b/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
@@ -307,17 +307,17 @@ public class FriendsOnMapPlugin extends Plugin {
     g.setFont(font);
     FontMetrics fm = g.getFontMetrics();
     int n_width = fm.stringWidth(label);
-    icon = new BufferedImage(icon.getWidth() + n_width + 10, icon.getHeight(), BufferedImage.TYPE_INT_ARGB);
+    icon = new BufferedImage(icon.getWidth() + n_width + 10, Math.max(icon.getHeight(), fm.getHeight()) + 2, BufferedImage.TYPE_INT_ARGB);
     g = (Graphics2D) icon.getGraphics();
     g.setFont(font);
     g.setColor(new Color(0, 0, 0, 0.15f));
     g.fillRect(0, 0, icon.getWidth(), icon.getHeight());
     int x_off = d_size + 2 + 5;
     if (left) {
-      drawIcon(off_world, translated, g, icon.getWidth() - d_size - 1, 1);
+      drawIcon(off_world, translated, g, icon.getWidth() - d_size - 1, icon.getHeight() / 2 - d_size / 2);
       x_off = 0;
     } else {
-      drawIcon(off_world, translated, g, 1, 1);
+      drawIcon(off_world, translated, g, 1, icon.getHeight() / 2 - d_size / 2);
     }
     int s_y = (icon.getHeight() / 2) + (fm.getAscent() / 2);
     int s_x = x_off;

--- a/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
+++ b/src/main/java/com/sololegends/runelite/FriendsOnMapPlugin.java
@@ -293,6 +293,7 @@ public class FriendsOnMapPlugin extends Plugin {
     int d_size = config.dotSize();
     BufferedImage icon = new BufferedImage(d_size + 2, d_size + 2, BufferedImage.TYPE_INT_ARGB);
     Graphics2D g = (Graphics2D) icon.getGraphics();
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     if (!config.alwaysShowName()) {
       drawIcon(off_world, translated, g, 1, 1);
@@ -309,6 +310,7 @@ public class FriendsOnMapPlugin extends Plugin {
     int n_width = fm.stringWidth(label);
     icon = new BufferedImage(icon.getWidth() + n_width + 10, Math.max(icon.getHeight(), fm.getHeight()) + 2, BufferedImage.TYPE_INT_ARGB);
     g = (Graphics2D) icon.getGraphics();
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
     g.setFont(font);
     g.setColor(new Color(0, 0, 0, 0.15f));
     g.fillRect(0, 0, icon.getWidth(), icon.getHeight());


### PR DESCRIPTION
## This PR implements 3 improvements to the world map icon drawing.

### 1. Ensure antialiasing is always used for icon rendering.

Before, the translated/link icons for players in other dimensions were rendered with antialiasing, while icons for players in the overworld were not. This change ensures antialiasing is always used.

Before:
![AA Before](https://github.com/sololegends/runelite-friend-finder/assets/6306331/a5d5c982-dd7c-46f4-9be0-8bc446c2684f)

After:
![AA After](https://github.com/sololegends/runelite-friend-finder/assets/6306331/8c92177a-003f-4b24-aa18-f30d7eef34da)

### 2. When "Name on World Map" is enabled, ensure the translucent background rectangle fits the username text.

Before, when "Name on World Map" was enabled with a reduced dot size, the text background rectangle would be rendered too short, clipping username text. This change fits the rectangle to the dot height or font height, whichever is greater.

Before: 
![Font height before](https://github.com/sololegends/runelite-friend-finder/assets/6306331/e59affb0-e874-4504-8cf7-bd5ae0b510af)

After:
![Font height after](https://github.com/sololegends/runelite-friend-finder/assets/6306331/4574e6c7-9842-4680-a032-c286c0e542c9)

### 3. Implement more consistent dot/outline behavior.

Before, when using the "Off World as Outline" setting, the "dot size" referred to the main inner circle, while "outline size" was a ring outline stroke around the dot. When using certain combinations of dot size and outline size this could cause inconsistencies. Additionally, the outline could clip outside the background rectangle when using "Name on World Map" mode.

This change makes "dot size" refer to the full area, including the outline, while "outline size" moves inward from the dot circumference. This change makes the dots/outlines behave more consistently with expected behavior.

Before (dot size: 7, outline size: 22):
![2023-11-09_18-18-32](https://github.com/sololegends/runelite-friend-finder/assets/6306331/9daca18a-3a62-44d4-885b-6461a52670ae)

After (dot size: 7, outline size: 22):
![2023-11-09_18-22-08](https://github.com/sololegends/runelite-friend-finder/assets/6306331/aabe3541-00a6-4565-84bc-a129551aee3f)
